### PR TITLE
ID-1 OptionalData2 support

### DIFF
--- a/mrz.php
+++ b/mrz.php
@@ -635,8 +635,10 @@ class SolidusMRZ {
 			$checkDigitVerify3  = $this->checkDigitVerify( $expiryRaw, $checkDigit3 );
 			
 			$nationality        = $this->getCountry( $this->stripPadding( substr($mrz, 45, 3) ) );
-		
-			$finalCheckDigitRaw = $documentNumberRaw . $checkDigit1 . $dobRaw . $checkDigit2 . $expiryRaw . $checkDigit3;
+			
+			$optionalData2      = $this->stripPadding( substr($mrz, 48, 11) );
+			
+			$finalCheckDigitRaw = $documentNumberRaw . $checkDigit1 . $dobRaw . $checkDigit2 . $expiryRaw . $checkDigit3 . $optionalData2;
 			$checkDigit4        = substr($mrz, 59, 1);
 			$checkDigitVerify4  = $this->checkDigitVerify( $finalCheckDigitRaw, $checkDigit4);
 			
@@ -649,6 +651,7 @@ class SolidusMRZ {
 			$id['names']            = $names;
 			$id['documentNumber']   = $documentNumber;
 			$id['optionalData']     = $optionalData;
+			$id['optionalData2']    = $optionalData2;
 			$id['nationality']      = $nationality;
 			$id['dob']              = $dob;
 			$id['sex']              = $sex;


### PR DESCRIPTION
For my country's ID-1 cards the validation was failing.

It turned out that current code does not take into consideration the second Optional Data on line 2.
See [wikipedia](https://en.wikipedia.org/wiki/Machine-readable_passport#Official_travel_documents): second row, positions 19–29, length 11.

In my case this field contains a Personal Number which was not included in the checksum and the validation was failing (neither was the field available in the parsed array).

This PR fixes the issue.


