### PR TITLE
Fix finalCheckDigitRaw generation into parseMRZID1

### DIFF
--- a/mrz.php
+++ b/mrz.php
@@ -658,7 +658,8 @@ class SolidusMRZ {
             $checkDigit1        = substr($mrz, 14, 1);
             $checkDigitVerify1  = $this->checkDigitVerify( $documentNumberRaw, $checkDigit1 );
 
-            $optionalData       = $this->stripPadding( substr($mrz, 15, 15) );
+            $optionalDataRaw    = substr($mrz, 15, 15);
+            $optionalData       = $this->stripPadding( $optionalDataRaw );
 
             $dobRaw             = substr($mrz, 30, 6);
             $dob                = $this->getFullDate( $this->stripPadding( $dobRaw), 1 );
@@ -675,9 +676,10 @@ class SolidusMRZ {
 
             $nationality        = $this->getCountry( $this->stripPadding( substr($mrz, 45, 3) ) );
 
-            $optionalData2      = $this->stripPadding( substr($mrz, 48, 11) );
+            $optionalData2Raw   = substr($mrz, 48, 11);
+            $optionalData2      = $this->stripPadding( $optionalData2Raw );
 
-            $finalCheckDigitRaw = $documentNumberRaw . $checkDigit1 . $dobRaw . $checkDigit2 . $expiryRaw . $checkDigit3 . $optionalData2;
+            $finalCheckDigitRaw = $documentNumberRaw . $checkDigit1 . $optionalDataRaw . $dobRaw . $checkDigit2 . $expiryRaw . $checkDigit3 . $optionalData2Raw;
             $checkDigit4        = substr($mrz, 59, 1);
             $checkDigitVerify4  = $this->checkDigitVerify( $finalCheckDigitRaw, $checkDigit4);
 


### PR DESCRIPTION
Optional Data is missing into the creation of the finalCheckDigitRaw var giving a wrong checkDigitVerify result (Source : https://github.com/Arg0s1080/mrz/blob/c462e0c8ca72f0396b9d1d17062434cd1c32b76a/mrz/checker/td1.py#L42)